### PR TITLE
Refactor namespaces to OpalStudio.CustomToolbar

### DIFF
--- a/Editor/Core/Data/ToolbarConfiguration.cs
+++ b/Editor/Core/Data/ToolbarConfiguration.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.Core.Data
+namespace OpalStudio.CustomToolbar.Editor.Core.Data
 {
       public sealed class ToolbarConfiguration : ScriptableObject
       {

--- a/Editor/Core/Data/ToolbarElement.cs
+++ b/Editor/Core/Data/ToolbarElement.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CustomToolbar.Editor.Core.Data
+namespace OpalStudio.CustomToolbar.Editor.Core.Data
 {
       [Serializable]
       public class ToolbarElement

--- a/Editor/Core/Data/ToolbarGroup.cs
+++ b/Editor/Core/Data/ToolbarGroup.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace CustomToolbar.Editor.Core.Data
+namespace OpalStudio.CustomToolbar.Editor.Core.Data
 {
       [Serializable]
       public class ToolbarGroup

--- a/Editor/Core/Data/ToolbarSide.cs
+++ b/Editor/Core/Data/ToolbarSide.cs
@@ -1,4 +1,4 @@
-﻿namespace CustomToolbar.Editor.Core.Data
+﻿namespace OpalStudio.CustomToolbar.Editor.Core.Data
 {
       public enum ToolbarSide
       {

--- a/Editor/Core/Data/ToolboxShortcut.cs
+++ b/Editor/Core/Data/ToolboxShortcut.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace CustomToolbar.Editor.Core.Data
+namespace OpalStudio.CustomToolbar.Editor.Core.Data
 {
       [Serializable]
       public class ToolboxShortcut

--- a/Editor/Core/ToolbarCallback.cs
+++ b/Editor/Core/ToolbarCallback.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEngine.UIElements;
 using Object = UnityEngine.Object;
 
-namespace CustomToolbar.Editor.Core
+namespace OpalStudio.CustomToolbar.Editor.Core
 {
       /// <summary>
       /// Provides a callback system for injecting custom GUI elements into Unity's toolbar.

--- a/Editor/Core/ToolbarInitializer.cs
+++ b/Editor/Core/ToolbarInitializer.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using CustomToolbar.Editor.Core.Data;
-using CustomToolbar.Editor.Settings;
-using CustomToolbar.Editor.ToolbarElements;
+using OpalStudio.CustomToolbar.Editor.Core.Data;
+using OpalStudio.CustomToolbar.Editor.Settings;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.Core
+namespace OpalStudio.CustomToolbar.Editor.Core
 {
       /// <summary>
       /// Initializes and manages custom toolbar elements based on configuration settings.

--- a/Editor/Core/ToolbarStyles.cs
+++ b/Editor/Core/ToolbarStyles.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace CustomToolbar.Editor.Core
+namespace OpalStudio.CustomToolbar.Editor.Core
 {
       /// <summary>
       /// Provides reusable style definitions for toolbar elements in Unity editor extensions.

--- a/Editor/Settings/MenuItemBrowser.cs
+++ b/Editor/Settings/MenuItemBrowser.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.Settings
+namespace OpalStudio.CustomToolbar.Editor.Settings
 {
       public sealed class MenuItemBrowser : EditorWindow
       {
@@ -84,7 +84,7 @@ namespace CustomToolbar.Editor.Settings
 
             private void DrawHeader()
             {
-                  var headerRect = new Rect(0, 0, position.width, HeaderHeight);
+                  var headerRect = new Rect(0, 0, this.position.width, HeaderHeight);
                   EditorGUI.DrawRect(headerRect, _headerColor);
 
                   var searchRect = new Rect(headerRect.x + 10, headerRect.y + 10, headerRect.width - 20, 20);

--- a/Editor/Settings/ToolbarSettings.cs
+++ b/Editor/Settings/ToolbarSettings.cs
@@ -1,13 +1,13 @@
 ﻿using System.IO;
-using CustomToolbar.Editor.Core.Data;
-using CustomToolbar.Editor.ToolbarElements;
-using CustomToolbar.Editor.ToolbarElements.Favorites;
-using CustomToolbar.Editor.ToolbarElements.MissingReferences;
-using CustomToolbar.Editor.ToolbarElements.SceneBookmarks;
+using OpalStudio.CustomToolbar.Editor.Core.Data;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.Settings
+namespace OpalStudio.CustomToolbar.Editor.Settings
 {
       /// <summary>
       /// Manages the loading, creation, and caching of toolbar configuration settings.

--- a/Editor/Settings/ToolbarSettingsProvider.cs
+++ b/Editor/Settings/ToolbarSettingsProvider.cs
@@ -2,15 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using CustomToolbar.Editor.Core.Data;
-using CustomToolbar.Editor.ToolbarElements;
+using OpalStudio.CustomToolbar.Editor.Core.Data;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
 using UnityEngine.UIElements;
 using Object = UnityEngine.Object;
 
-namespace CustomToolbar.Editor.Settings
+namespace OpalStudio.CustomToolbar.Editor.Settings
 {
       /// <summary>
       /// Unity Settings Provider for Custom Toolbar configuration.

--- a/Editor/ToolbarElements/BaseToolbarElement.cs
+++ b/Editor/ToolbarElements/BaseToolbarElement.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEditor;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       /// <summary>
       /// The base contract for any element that can be displayed on the Custom Toolbar.

--- a/Editor/ToolbarElements/Favorites/Data/FavoriteItem.cs
+++ b/Editor/ToolbarElements/Favorites/Data/FavoriteItem.cs
@@ -1,4 +1,4 @@
-﻿namespace CustomToolbar.Editor.ToolbarElements.Favorites.Data
+﻿namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Data
 {
       [System.Serializable]
       public class FavoriteItem

--- a/Editor/ToolbarElements/Favorites/Data/FavoriteList.cs
+++ b/Editor/ToolbarElements/Favorites/Data/FavoriteList.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace CustomToolbar.Editor.ToolbarElements.Favorites.Data
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Data
 {
       [System.Serializable]
       public class FavoriteList

--- a/Editor/ToolbarElements/Favorites/Data/FavoritesManager.cs
+++ b/Editor/ToolbarElements/Favorites/Data/FavoritesManager.cs
@@ -2,7 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.Favorites.Data
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Data
 {
       public sealed class FavoritesManager : ScriptableObject
       {

--- a/Editor/ToolbarElements/Favorites/ToolbarFavorites.cs
+++ b/Editor/ToolbarElements/Favorites/ToolbarFavorites.cs
@@ -1,9 +1,9 @@
-﻿using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.ToolbarElements.Favorites.Window;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Window;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.Favorites
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites
 {
       sealed internal class ToolbarFavorites : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/Favorites/Window/FavoritesWindow.cs
+++ b/Editor/ToolbarElements/Favorites/Window/FavoritesWindow.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using CustomToolbar.Editor.ToolbarElements.Favorites.Data;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Data;
 using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-namespace CustomToolbar.Editor.ToolbarElements.Favorites.Window
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Window
 {
       public sealed class FavoritesWindow : EditorWindow
       {

--- a/Editor/ToolbarElements/MissingReferences/Data/MissingReferenceInfo.cs
+++ b/Editor/ToolbarElements/MissingReferences/Data/MissingReferenceInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace CustomToolbar.Editor.ToolbarElements.MissingReferences.Data
+﻿namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Data
 {
       internal struct MissingReferenceInfo
       {

--- a/Editor/ToolbarElements/MissingReferences/ToolbarFindMissingReferences.cs
+++ b/Editor/ToolbarElements/MissingReferences/ToolbarFindMissingReferences.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
-using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.ToolbarElements.MissingReferences.Data;
-using CustomToolbar.Editor.ToolbarElements.MissingReferences.Window;
+using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Data;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Window;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace CustomToolbar.Editor.ToolbarElements.MissingReferences
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences
 {
       sealed internal class ToolbarFindMissingReferences : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/MissingReferences/Window/MissingReferencesWindow.cs
+++ b/Editor/ToolbarElements/MissingReferences/Window/MissingReferencesWindow.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using CustomToolbar.Editor.ToolbarElements.MissingReferences.Data;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Data;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.MissingReferences.Window
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Window
 {
       sealed internal class MissingReferencesWindow : EditorWindow
       {

--- a/Editor/ToolbarElements/SceneBookmarks/Data/SceneBookmark.cs
+++ b/Editor/ToolbarElements/SceneBookmarks/Data/SceneBookmark.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data
 {
       [Serializable]
       public class SceneBookmark

--- a/Editor/ToolbarElements/SceneBookmarks/Data/SceneBookmarksManager.cs
+++ b/Editor/ToolbarElements/SceneBookmarks/Data/SceneBookmarksManager.cs
@@ -3,7 +3,7 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data
 {
       public sealed class SceneBookmarksManager : ScriptableObject
       {

--- a/Editor/ToolbarElements/SceneBookmarks/ToolbarSceneBookmarks.cs
+++ b/Editor/ToolbarElements/SceneBookmarks/ToolbarSceneBookmarks.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
-using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data;
-using CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Window;
+using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data;
+using OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Window;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.SceneBookmarks
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks
 {
       sealed internal class ToolbarSceneBookmarks : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/SceneBookmarks/Window/SceneBookmarksWindow.cs
+++ b/Editor/ToolbarElements/SceneBookmarks/Window/SceneBookmarksWindow.cs
@@ -1,8 +1,8 @@
-﻿using CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data;
+﻿using OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Data;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Window
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.SceneBookmarks.Window
 {
       public sealed class SceneBookmarksWindow : EditorWindow
       {

--- a/Editor/ToolbarElements/ToolbarClearPlayerPrefs.cs
+++ b/Editor/ToolbarElements/ToolbarClearPlayerPrefs.cs
@@ -1,8 +1,8 @@
-﻿using CustomToolbar.Editor.Core;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarClearPlayerPrefs : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarEnterPlayMode.cs
+++ b/Editor/ToolbarElements/ToolbarEnterPlayMode.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarEnterPlayMode : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarFpsSlider.cs
+++ b/Editor/ToolbarElements/ToolbarFpsSlider.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarFpsSlider : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarGitStatus.cs
+++ b/Editor/ToolbarElements/ToolbarGitStatus.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.Utils;
+using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarGitStatus : BaseToolbarElement
       {
@@ -19,7 +19,7 @@ namespace CustomToolbar.Editor.ToolbarElements
 
             public override void OnInit()
             {
-                  Width = 100;
+                  this.Width = 100;
                   buttonContent = new GUIContent();
                   RefreshStatus();
 
@@ -29,7 +29,7 @@ namespace CustomToolbar.Editor.ToolbarElements
 
             public override void OnDrawInToolbar()
             {
-                  if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Keyboard, ToolbarStyles.CommandPopupStyle, GUILayout.Width(Width)))
+                  if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Keyboard, ToolbarStyles.CommandPopupStyle, GUILayout.Width(this.Width)))
                   {
                         BuildGitMenu().ShowAsContext();
                   }

--- a/Editor/ToolbarElements/ToolbarLayerVisibility.cs
+++ b/Editor/ToolbarElements/ToolbarLayerVisibility.cs
@@ -1,8 +1,8 @@
-﻿using CustomToolbar.Editor.Core;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarLayerVisibility : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarRecompile.cs
+++ b/Editor/ToolbarElements/ToolbarRecompile.cs
@@ -1,9 +1,9 @@
-﻿using CustomToolbar.Editor.Core;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEditor.Compilation;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarRecompile : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarReloadScene.cs
+++ b/Editor/ToolbarElements/ToolbarReloadScene.cs
@@ -1,9 +1,9 @@
-﻿using CustomToolbar.Editor.Core;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarReloadScene : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarReserializeAll.cs
+++ b/Editor/ToolbarElements/ToolbarReserializeAll.cs
@@ -1,9 +1,9 @@
-﻿using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.Utils;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarReserializeAll : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarSaveProject.cs
+++ b/Editor/ToolbarElements/ToolbarSaveProject.cs
@@ -1,9 +1,9 @@
-﻿using CustomToolbar.Editor.Core;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarSaveProject : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarSceneSelection.cs
+++ b/Editor/ToolbarElements/ToolbarSceneSelection.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarSceneSelection : BaseToolbarElement
       {
@@ -20,7 +20,7 @@ namespace CustomToolbar.Editor.ToolbarElements
 
             public override void OnInit()
             {
-                  Width = 120;
+                  this.Width = 120;
 
                   EditorSceneManager.sceneOpened -= OnSceneChanged;
                   EditorSceneManager.sceneOpened += OnSceneChanged;
@@ -53,7 +53,7 @@ namespace CustomToolbar.Editor.ToolbarElements
                               return;
                         }
 
-                        if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Keyboard, ToolbarStyles.CommandPopupStyle, GUILayout.Width(Width)))
+                        if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Keyboard, ToolbarStyles.CommandPopupStyle, GUILayout.Width(this.Width)))
                         {
                               BuildSceneMenu().ShowAsContext();
                         }
@@ -66,14 +66,24 @@ namespace CustomToolbar.Editor.ToolbarElements
 
                   if (scenePaths.Count == 0)
                   {
-                        menu.AddDisabledItem(new GUIContent("No scenes found in Assets/Scenes"));
+                        menu.AddDisabledItem(new GUIContent("No scenes found in project"));
 
                         return menu;
                   }
 
+                  var ignoredScenes = new List<string> { "Basic", "Standard" };
+
                   foreach (string path in scenePaths)
                   {
-                        string menuPath = path["Assets/Scenes/".Length..].Replace(".unity", "", StringComparison.Ordinal);
+                        string sceneName = System.IO.Path.GetFileNameWithoutExtension(path);
+
+                        if (ignoredScenes.Contains(sceneName))
+                        {
+                              continue;
+                        }
+
+                        string menuPath = path.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase) ? path.Substring("Assets/".Length) : path;
+                        menuPath = menuPath.EndsWith(".unity", StringComparison.OrdinalIgnoreCase) ? menuPath.Substring(0, menuPath.Length - ".unity".Length) : menuPath;
 
                         if (buildSceneData.TryGetValue(path, out int buildIndex))
                         {
@@ -106,10 +116,7 @@ namespace CustomToolbar.Editor.ToolbarElements
                   {
                         string path = AssetDatabase.GUIDToAssetPath(guid);
 
-                        if (path.StartsWith("Assets/Scenes/", StringComparison.Ordinal))
-                        {
-                              scenePaths.Add(path);
-                        }
+                        scenePaths.Add(path);
                   }
 
                   scenePaths.Sort(static (pathA, pathB) =>
@@ -121,9 +128,7 @@ namespace CustomToolbar.Editor.ToolbarElements
                   });
 
                   Scene activeScene = SceneManager.GetActiveScene();
-
                   Texture sceneIcon = EditorGUIUtility.IconContent("d_SceneAsset Icon").image;
-
                   buttonContent = new GUIContent(activeScene.name, sceneIcon, Tooltip);
             }
 

--- a/Editor/ToolbarElements/ToolbarScreenshot.cs
+++ b/Editor/ToolbarElements/ToolbarScreenshot.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.IO;
-using CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Core;
 using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarScreenshot : BaseToolbarElement
       {
@@ -22,7 +22,7 @@ namespace CustomToolbar.Editor.ToolbarElements
 
             public override void OnDrawInToolbar()
             {
-                  if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Passive, ToolbarStyles.CommandButtonStyle, GUILayout.Width(Width)))
+                  if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Passive, ToolbarStyles.CommandButtonStyle, GUILayout.Width(this.Width)))
                   {
                         var menu = new GenericMenu();
                         menu.AddItem(new GUIContent("Capture Game View"), false, CaptureGameView);

--- a/Editor/ToolbarElements/ToolbarSpace.cs
+++ b/Editor/ToolbarElements/ToolbarSpace.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarSpace : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarStartFromFirstScene.cs
+++ b/Editor/ToolbarElements/ToolbarStartFromFirstScene.cs
@@ -1,10 +1,10 @@
-﻿using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.Utils;
+﻿using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarStartFromFirstScene : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarTimeSlider.cs
+++ b/Editor/ToolbarElements/ToolbarTimeSlider.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEditor;
 using UnityEngine;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarTimeSlider : BaseToolbarElement
       {

--- a/Editor/ToolbarElements/ToolbarToolbox.cs
+++ b/Editor/ToolbarElements/ToolbarToolbox.cs
@@ -2,14 +2,14 @@
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-using CustomToolbar.Editor.Core;
-using CustomToolbar.Editor.Core.Data;
-using CustomToolbar.Editor.Settings;
+using OpalStudio.CustomToolbar.Editor.Core;
+using OpalStudio.CustomToolbar.Editor.Core.Data;
+using OpalStudio.CustomToolbar.Editor.Settings;
 using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-namespace CustomToolbar.Editor.ToolbarElements
+namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 {
       sealed internal class ToolbarToolbox : BaseToolbarElement
       {
@@ -25,7 +25,7 @@ namespace CustomToolbar.Editor.ToolbarElements
 
             public override void OnDrawInToolbar()
             {
-                  if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Passive, ToolbarStyles.CommandButtonStyle, GUILayout.Width(Width)))
+                  if (EditorGUILayout.DropdownButton(buttonContent, FocusType.Passive, ToolbarStyles.CommandButtonStyle, GUILayout.Width(this.Width)))
                   {
                         GenerateMenu().ShowAsContext();
                   }

--- a/Editor/Utils/GitUtils.cs
+++ b/Editor/Utils/GitUtils.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
-namespace CustomToolbar.Editor.Utils
+namespace OpalStudio.CustomToolbar.Editor.Utils
 {
       public static class GitUtils
       {

--- a/Editor/Utils/SceneAssetsUtils.cs
+++ b/Editor/Utils/SceneAssetsUtils.cs
@@ -3,7 +3,7 @@ using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-namespace CustomToolbar.Editor.Utils
+namespace OpalStudio.CustomToolbar.Editor.Utils
 {
       internal static class SceneAssetsUtils
       {
@@ -29,17 +29,6 @@ namespace CustomToolbar.Editor.Utils
                         string firstScenePath = EditorBuildSettings.scenes[0].path;
                         EditorSceneManager.OpenScene(firstScenePath);
                         EditorApplication.isPlaying = true;
-                  }
-            }
-
-            public static void RestoreSceneAfterPlay()
-            {
-                  string sceneToRestore = SessionState.GetString(LastActiveSceneStateKey, string.Empty);
-
-                  if (!string.IsNullOrEmpty(sceneToRestore))
-                  {
-                        EditorSceneManager.OpenScene(sceneToRestore);
-                        SessionState.EraseString(LastActiveSceneStateKey);
                   }
             }
       }

--- a/Editor/Utils/SerializeAssetsUtils.cs
+++ b/Editor/Utils/SerializeAssetsUtils.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEditor;
 
-namespace CustomToolbar.Editor.Utils
+namespace OpalStudio.CustomToolbar.Editor.Utils
 {
       internal static class SerializeAssetsUtils
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.opalstudio.customtoolbar",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "displayName": "CustomToolbar",
     "description": "A Unity package that provides a custom toolbar for the Unity Editor, allowing developers to create and manage custom editor tools and functionalities.",
     "unity": "2021.3",
@@ -9,7 +9,8 @@
     "license": "MIT",
     "author": {
         "name": "Alaxxxx",
-        "email": "contact@opalstudio.fr"
+        "email": "contact@opalstudio.fr",
+        "url": "https://opalstudio.fr"
     },
     "keywords": [
         "unity",


### PR DESCRIPTION
All C# files have been updated to use the 'OpalStudio.CustomToolbar' namespace instead of 'CustomToolbar'. Minor code improvements were made, such as using 'this' for member access and updating scene filtering logic. The package.json author now includes a URL. And packages bump to 2.5.2