### PR TITLE
Fixed not clickable FPS toolbar's input field.

### DIFF
--- a/Editor/ToolbarElements/ToolbarFpsSlider.cs
+++ b/Editor/ToolbarElements/ToolbarFpsSlider.cs
@@ -33,7 +33,7 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements
 
                   EditorGUI.BeginChangeCheck();
 
-                  currentFPS = EditorGUILayout.IntSlider(currentFPS, MinFpsValue, MaxFpsValue, GUILayout.Width(this.Width - 65));
+                  currentFPS = Mathf.RoundToInt(EditorGUILayout.Slider(currentFPS, MinFpsValue, MaxFpsValue, GUILayout.Width(this.Width - 65)));
 
                   if (EditorGUI.EndChangeCheck())
                   {


### PR DESCRIPTION
Unity 2022.3.62f1, Win. 
**Issue**
Input field of the FPS slider is not clickable; to change its value it requires an additional press of Enter button to make the field editable.
Time toolbar slider does not have this issue. As it turns out, `EditorGUILayout.IntSlider()` behaves differently, and changing to `EditorGUILayout.Slider()` fixes the issue for me.

**Fix**
Update ToolbarFpsSlider.cs to use EditorGUILayout.Slider() similar to ToolbarTimeSlider.cs