### PR TITLE
Add Unity 6000.3+ compatibility for toolbar and item access

### DIFF
--- a/Editor/ToolbarElements/Favorites/Data/FavoriteItem.cs
+++ b/Editor/ToolbarElements/Favorites/Data/FavoriteItem.cs
@@ -50,7 +50,12 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.Favorites.Data
                         case FavoriteItemType.Asset:
                               return AssetDatabase.LoadAssetAtPath<Object>(AssetDatabase.GUIDToAssetPath(guid));
                         case FavoriteItemType.GameObject:
+#if UNITY_6000_3_OR_NEWER
+                              return !IsSceneLoaded() ? null : EditorUtility.EntityIdToObject(instanceID);
+#else
+
                               return !IsSceneLoaded() ? null : EditorUtility.InstanceIDToObject(instanceID);
+#endif
 
                         default:
                               return null;

--- a/Editor/ToolbarElements/MissingReferences/Window/MissingReferencesWindow.cs
+++ b/Editor/ToolbarElements/MissingReferences/Window/MissingReferencesWindow.cs
@@ -71,9 +71,7 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Wind
                   int missingScripts = _results.Values.Sum(static list => list.Count(static info => info.IsScriptMissing));
                   int nullRefs = totalProblems - missingScripts;
 
-                  string headerText = totalProblems > 0
-                              ? $"{totalProblems} Issue(s) Found • {missingScripts} Missing Scripts • {nullRefs} Null References"
-                              : "🎉 No Missing References!";
+                  string headerText = totalProblems > 0 ? $"{totalProblems} Issue(s) Found • {missingScripts} Missing Scripts • {nullRefs} Null References" : "🎉 No Missing References!";
 
                   EditorGUILayout.LabelField(headerText, EditorStyles.boldLabel);
                   EditorGUILayout.EndVertical();
@@ -191,8 +189,7 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Wind
                   {
                         EditorGUI.indentLevel++;
 
-                        IEnumerable<IGrouping<string, MissingReferenceInfo>> groupedByComponent =
-                                    infos.GroupBy(static info => info.IsScriptMissing ? "Missing Script" : info.ComponentName);
+                        IEnumerable<IGrouping<string, MissingReferenceInfo>> groupedByComponent = infos.GroupBy(static info => info.IsScriptMissing ? "Missing Script" : info.ComponentName);
 
                         foreach (IGrouping<string, MissingReferenceInfo> group in groupedByComponent)
                         {
@@ -334,7 +331,11 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Wind
                               if (parts.Length >= 3)
                               {
                                     int instanceId = int.Parse(parts[0]);
+#if UNITY_6000_3_OR_NEWER
+                                    var go = EditorUtility.EntityIdToObject(instanceId) as GameObject;
+#else
                                     var go = EditorUtility.InstanceIDToObject(instanceId) as GameObject;
+#endif
 
                                     if (go)
                                     {
@@ -389,7 +390,11 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Wind
                         {
                               string[] parts = itemKey.Split('_');
                               int instanceId = int.Parse(parts[0]);
+#if UNITY_6000_3_OR_NEWER
+                              var go = EditorUtility.EntityIdToObject(instanceId) as GameObject;
+#else
                               var go = EditorUtility.InstanceIDToObject(instanceId) as GameObject;
+#endif
 
                               if (go && RemoveMissingScriptFromObject(go))
                               {
@@ -474,8 +479,8 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.MissingReferences.Wind
                         {
                               if (component && component.GetType().Name == info.ComponentName)
                               {
-                                    if (EditorUtility.DisplayDialog("Remove Component",
-                                                    $"Remove component '{info.ComponentName}' from '{go.name}'?\n\nThis action cannot be undone.", "Remove", "Cancel"))
+                                    if (EditorUtility.DisplayDialog("Remove Component", $"Remove component '{info.ComponentName}' from '{go.name}'?\n\nThis action cannot be undone.", "Remove",
+                                                    "Cancel"))
                                     {
                                           DestroyImmediate(component);
                                           EditorUtility.SetDirty(go);

--- a/Editor/ToolbarElements/QuickAccess/Data/QuickAccessItem.cs
+++ b/Editor/ToolbarElements/QuickAccess/Data/QuickAccessItem.cs
@@ -55,7 +55,11 @@ namespace OpalStudio.CustomToolbar.Editor.ToolbarElements.QuickAccess.Data
                   return ItemType switch
                   {
                               QuickAccessItemType.Asset or QuickAccessItemType.Scene => AssetDatabase.LoadAssetAtPath<Object>(AssetDatabase.GUIDToAssetPath(Guid)),
+#if UNITY_6000_3_OR_NEWER
+                              QuickAccessItemType.GameObject => EditorUtility.EntityIdToObject(InstanceID),
+#else
                               QuickAccessItemType.GameObject => EditorUtility.InstanceIDToObject(InstanceID),
+#endif
                               _ => null
                   };
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.opalstudio.customtoolbar",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "displayName": "CustomToolbar",
     "description": "A Unity package that provides a custom toolbar for the Unity Editor, allowing developers to create and manage custom editor tools and functionalities.",
     "unity": "2021.3",


### PR DESCRIPTION
Introduces support for Unity 6000.3 and newer, updating toolbar injection and object access logic to use EntityIdToObject where required. Also bumps package version to 2.8.0.
Closes #12