### PR TITLE
Fixed ToolbarInitializer causing AssetDatabase calls in a static cons…

### DIFF
--- a/Editor/Core/ToolbarInitializer.cs
+++ b/Editor/Core/ToolbarInitializer.cs
@@ -20,8 +20,10 @@ namespace OpalStudio.CustomToolbar.Editor.Core
             private readonly static List<BaseToolbarElement> LeftElements = new();
             private readonly static List<BaseToolbarElement> RightElements = new();
 
-            static ToolbarInitializer()
-            {
+            static ToolbarInitializer() => EditorApplication.delayCall += Initialize;
+
+            static void Initialize()
+             {
                   ToolbarConfiguration config = ToolbarSettings.Instance;
 
                   CreateElementsFromConfig(config);


### PR DESCRIPTION
## Issue Summary
I imported the package from a git link, and immediately run into a problem with settings loading.
Basically, on first import, the package fails to load CustomToolbarSettings.asset from disk and overwrites it with default settings.
This makes it impossible to create a persistent settings file pushed to our repo, everyone checking out the project ends up with the default toolbar.

## Repro
* Create a version controlled Unity project.
* Import CustomToolbar into PackageManager.
* Modify the settings.
 * I just disabled most groups, as we don't need them. 
* Save.
* Commit packages.json and CustomToolbarSettings.asset
* Check out a branch that doesn't contain the CustomToolbar package.
* Open the project in Unity.
* Check out the branch that does contain the CustomToolbar package.
* Open the project in Unity

## Expected result
The project should open with the CustomToolbar settings persisted.

## Actual result
The project opens with default CustomToolbar settings.
 
## Proposed fix

I tracked this down to the context of initialization for the whole package in ToolbarInitializer. Running the AssetDatabase load call in the static constructor context fails, since this is before the Unity serialization process.

The simple solution is to use EditorApplication.delayCall to initialize CustomToolbar.

I'm submitting this as a pull request, but if you do not like the fix feel free to reject it and implement your own, I'll keep the package embedded with my fix until it's fixed on the master repo.